### PR TITLE
import parser fix, python3 support, readme for OSX

### DIFF
--- a/protobuf2uml/README.md
+++ b/protobuf2uml/README.md
@@ -42,6 +42,8 @@ As of April 2016, on Ubuntu v14.04 the following command installed an old versio
 
 (I referred to [here](http://www.confusedcoders.com/random/how-to-install-protocol-buffer-2-5-0-on-ubuntu-13-04) and [here](https://github.com/BVLC/caffe/issues/2092#issuecomment-98917616) for protobuf installation help)
 
+> For installing on Mac you can use `brew` for all dependencies. You will need to install `graphviz`, `libprotoc`, `python`, `wget`, and the python package using `pip3 install protobuf`.
+
 **2)** Make sure you have the following files in the same directory:
 
 make_uml.sh  

--- a/protobuf2uml/clean_imports.py
+++ b/protobuf2uml/clean_imports.py
@@ -1,0 +1,27 @@
+#! /usr/bin/python
+import fileinput, sys
+
+"""
+Author: Orkun Duman
+
+Replaces user-defined package imports with no path.
+
+For example,
+  import "ga4gh/common.proto";
+  import "google/protobuf/type.proto";
+    becomes
+  import "common.proto";
+  import "type.proto";
+"""
+
+def main(args):
+    file_name = args[1]
+    for line in fileinput.input(file_name, inplace=True):
+        if line.startswith("import \""):
+            last_index = line.rfind('/')
+            if last_index >= 0:
+                line = "import \"" + line[last_index+1:]
+        sys.stdout.write(line)
+
+if __name__ == "__main__" :
+    sys.exit(main(sys.argv))

--- a/protobuf2uml/clean_imports.py
+++ b/protobuf2uml/clean_imports.py
@@ -19,7 +19,7 @@ def main(args):
     for line in fileinput.input(file_name, inplace=True):
         if line.startswith("import \""):
             last_index = line.rfind('/')
-            if last_index >= 0:
+            if last_index >= 0 and "google/protobuf/" not in line:
                 line = "import \"" + line[last_index+1:]
         sys.stdout.write(line)
 

--- a/protobuf2uml/make_uml.sh
+++ b/protobuf2uml/make_uml.sh
@@ -2,25 +2,25 @@
 
 # Author: Malisa Smith
 
+# Replace with "python3" if you use python3 to access python v3.
+PYTHON=python
+
 # Download all the proto schema files into the schemas_proto folder
 # First clean-up old files from previous runs
 rm -rf schemas_proto/*
+
 # Obtain the raw github url's if not raw already:
-raw_schema_urls=$(python url_converter.py --getrawfromfile schema_urls)
+raw_schema_urls=$($PYTHON url_converter.py --getrawfromfile schema_urls)
 for raw_url in ${raw_schema_urls};
 do
     wget --timestamping --directory-prefix ./schemas_proto ${raw_url};
 done
 
 # Replace user-defined package imports with no path. This allows proto files to find each other.
-#For example,     import "ga4gh/common.proto";       becomes       import "common.proto";
+# For example,     import "ga4gh/common.proto";       becomes       import "common.proto";
 for proto_file in schemas_proto/*; do
-    sed -e 's:ga4gh/::g' $proto_file > $proto_file.tmp && mv $proto_file.tmp $proto_file
-    # sed -i '' s/ga4gh\///g $proto_file
+    $($PYTHON clean_imports.py $proto_file)
 done
-
-# Remove any temporary files in the schemas_proto directory which have have been created as a result of editing, etc:
-#rm -rf schemas_proto/*~
 
 # Generate descriptor_pb2.py with protoc:
 protoc descriptor.proto --python_out=.
@@ -31,7 +31,7 @@ protoc --include_source_info -o MyFileDescriptorSet.pb *
 cd ../
 
 # Make the dot file which describes the UML diagram. The type_header_comments file can be empty (or you can remove the option altogether)
-python descriptor2uml.py --descriptor ./schemas_proto/MyFileDescriptorSet.pb --dot uml.dot --urls schema_urls #--type_comments type_header_comments 
+$PYTHON descriptor2uml.py --descriptor ./schemas_proto/MyFileDescriptorSet.pb --dot uml.dot --urls schema_urls #--type_comments type_header_comments 
 
 # Finally, draw the UMl diagram
 dot uml.dot -T svg -o uml.svg


### PR DESCRIPTION
The last pull request broke import parsing as it was looking for the specific phrase "ga4gh". This is fixed now using a python helper function. We also now allow "python" to be replaced with "python3" so the user does not have to create an alias. Finally, added some help for installing for OSX as i ran into some problems when doing so.